### PR TITLE
Documentation: Resend Contacts sync

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -249,32 +249,21 @@ vercel env add DOUBLE_OPTIN
 **What this means:** Tell the API which websites are allowed to use it (security feature).
 
 **How to do it:**
-1. Open `the-widget/api/shared/config.js` in a text editor
-2. Find the `CORS_CONFIG` section (around line 27)
-3. Replace `yourdomain.com` with your actual website domain(s):
-
-```js
-export const CORS_CONFIG = {
-  allowedOrigins: [
-    'https://yourdomain.com',        // ← Replace with your actual domain
-    'https://www.yourdomain.com',    // ← Replace if you use www
-    'http://localhost:4000',          // Keep this for local Jekyll testing
-  ],
-};
+```bash
+vercel env add CORS_ALLOWED_ORIGINS
 ```
 
-**Example:** If your site is `https://mysite.com`, it would look like:
-```js
-export const CORS_CONFIG = {
-  allowedOrigins: [
-    'https://mysite.com',
-    'https://www.mysite.com',
-    'http://localhost:4000',
-  ],
-};
+**When prompted:**
+- Enter your domains as a comma-separated list
+- Example: `https://mysite.com,https://www.mysite.com`
+- Select environment: Press Enter for all (Development, Preview, Production)
+
+**Example:** If your site is `https://mysite.com`, enter:
+```
+https://mysite.com,https://www.mysite.com
 ```
 
-**Save the file** after making changes.
+**Note:** Local development servers (`localhost:3000`, `localhost:4000`) are always allowed automatically.
 
 ---
 
@@ -598,6 +587,20 @@ See the main [README.md](../README.md) for framework-specific instructions. The 
 
 **❌ Having issues?** See the Troubleshooting section below.
 
+## Optional: Resend Contacts Sync
+
+**What it does:** Syncs confirmed subscribers to a Resend Audience for marketing emails, with two-way sync for bounces and unsubscribes.
+
+**When to add:** If you plan to send marketing/newsletter emails to confirmed waitlist subscribers.
+
+**Quick setup:**
+1. Create an Audience at [resend.com/audiences](https://resend.com/audiences)
+2. Add to Vercel: `vercel env add RESEND_AUDIENCE_ID production`
+3. Set up webhooks at [resend.com/webhooks](https://resend.com/webhooks) pointing to `https://your-api.vercel.app/api/webhooks/resend`
+4. Redeploy: `vercel --prod`
+
+**For detailed setup instructions**, see the main [README.md](../README.md#2b-set-up-resend-contacts-sync-optional).
+
 ## Optional: Add Rate Limiting
 
 **What it does:** Prevents spam by limiting how many signups per IP address.
@@ -651,7 +654,7 @@ Replace `0x4AAAAAAA...` with your actual site key from Cloudflare.
 
 ### Form not submitting
 - Check that your API URL is correct in the include statement
-- Make sure CORS is configured for your domain in `api/shared/config.js`
+- Make sure `CORS_ALLOWED_ORIGINS` environment variable includes your domain
 - Check browser console (F12) for error messages
 
 ### Emails not arriving

--- a/the-widget/api/shared/README.md
+++ b/the-widget/api/shared/README.md
@@ -17,7 +17,7 @@ This directory contains shared modules used by the API endpoints. These modules 
 - Email template style selection (`TEMPLATE_CONFIG`)
 
 **To customize:**
-- **CORS origins:** Edit `CORS_CONFIG.allowedOrigins`
+- **CORS origins:** Set `CORS_ALLOWED_ORIGINS` environment variable (comma-separated domains)
 - **Feature flags:** Edit `FEATURES` object
 - **Rate limits:** Edit `RATE_LIMIT_CONFIG`
 - **Email template style:** Set `EMAIL_TEMPLATE_STYLE` environment variable to `minimal`, `professional`, or `branded`
@@ -70,6 +70,24 @@ This is the **only file you need to modify** to use SendGrid, Mailgun, AWS SES, 
 **To customize:**
 - Usually no changes needed
 - Works automatically with contacts table
+
+### `resend-contacts.js`
+**Resend Contacts API integration** - Syncs contacts to Resend Audience.
+
+**What's here:**
+- `syncContactToResend()` - Add/update contact in Resend Audience
+- `updateResendContact()` - Update existing contact
+- `unsubscribeResendContact()` - Mark contact as unsubscribed
+- `removeResendContact()` - Remove contact from audience
+- `isResendContactsSyncEnabled()` - Check if sync is configured
+
+**To customize:**
+- Set `RESEND_AUDIENCE_ID` environment variable to enable
+- Sync happens automatically on email confirmation and unsubscribe
+
+**Related:**
+- Webhook handler at `api/webhooks/resend.js` receives Resend events
+- Bulk sync script at `scripts/sync-contacts-to-resend.js`
 
 ### `utils.js`
 **Shared utilities** - Common helper functions.

--- a/the-widget/api/shared/config.js
+++ b/the-widget/api/shared/config.js
@@ -5,7 +5,7 @@
 // ⚠️ RESEND REQUIRED: The email service abstraction uses Resend.
 // If you want to use a different email service, modify api/shared/email-service.js
 export const EMAIL_CONFIG = {
-  fromEmail: process.env.FROM_EMAIL || 'Your Project <hello@yourdomain.com>',
+  fromEmail: process.env.FROM_EMAIL,
   resendApiKey: process.env.RESEND_API_KEY,
 };
 
@@ -36,14 +36,15 @@ export const APP_CONFIG = {
 };
 
 // CORS configuration
-// Add your domains here - these are the allowed origins for API requests
+// Set allowed origins via CORS_ALLOWED_ORIGINS env var (comma-separated)
+// Example: CORS_ALLOWED_ORIGINS=https://example.com,https://www.example.com
 export const CORS_CONFIG = {
   allowedOrigins: [
-    'https://yourdomain.com',
-    'https://www.yourdomain.com',
+    // Custom domains from environment variable
+    ...(process.env.CORS_ALLOWED_ORIGINS?.split(',').map(s => s.trim()).filter(Boolean) || []),
+    // Local development servers (always allowed)
     'http://localhost:3000',  // Vercel dev server
     'http://localhost:4000',  // Jekyll local dev
-    // Add more domains as needed
   ],
 };
 

--- a/the-widget/env.example
+++ b/the-widget/env.example
@@ -1,96 +1,66 @@
-# ===================================
-# WAITLIST WIDGET CONFIGURATION
-# ===================================
-# Copy this file to .env and fill in your values
+# ========================================
+# WAITLIST WIDGET - ENVIRONMENT VARIABLES
+# ========================================
+# Copy to .env and fill in your values
+# Docs: docs/QUICKSTART.md
 
-# ===================================
-# REQUIRED CONFIGURATION
-# ===================================
+# ----------------------------------------
+# REQUIRED
+# ----------------------------------------
 
-# Supabase Database Configuration
+# Supabase (https://supabase.com/dashboard → Settings → API)
 SUPABASE_URL=https://your-project.supabase.co
-SUPABASE_SERVICE_KEY=your-service-role-key-here
+SUPABASE_SERVICE_KEY=your-service-role-key
 
-# Resend Email Service (Required)
-RESEND_API_KEY=re_your-api-key-here
-FROM_EMAIL=Your Project <hello@yourdomain.com>
+# Resend (https://resend.com/api-keys)
+RESEND_API_KEY=re_xxxxx
+FROM_EMAIL="Your Project <hello@yourdomain.com>"
 
-# Resend Contacts Sync (Optional - for syncing confirmed subscribers)
-# Create an Audience at https://resend.com/audiences and paste the ID here
-# RESEND_AUDIENCE_ID=aud_xxxxxxxxx
-# Webhook signing secret (recommended - get from Resend webhook settings)
-# RESEND_WEBHOOK_SECRET=whsec_xxxxxxxxx
-
-# Application URLs
+# Your website URL (where confirmation pages live)
 BASE_URL=https://yourdomain.com
 
-# ===================================
-# EMAIL TEMPLATE CONFIGURATION
-# ===================================
+# CORS (comma-separated domains allowed to call API)
+CORS_ALLOWED_ORIGINS=https://yourdomain.com,https://www.yourdomain.com
 
-# Choose your email template style
-# Options: minimal (default), professional, branded
-# Note: 'default' is an alias for 'minimal' (backward compatibility)
+# ----------------------------------------
+# EMAIL BRANDING (optional, has defaults)
+# ----------------------------------------
+
+# Template style: minimal (default), professional, branded
 EMAIL_TEMPLATE_STYLE=minimal
 
-# Template Style Guide:
-# - minimal: Clean, simple design with minimal styling (default)
-# - professional: Elegant serif design with formal styling  
-# - branded: Custom colors, good for companies with strong brand identity
+# Branding (override defaults in templates/config.js)
+# EMAIL_PROJECT_NAME="Your Project"
+# EMAIL_SENDER_NAME="The Team"
+# EMAIL_PRIMARY_COLOR=#4f46e5
+# EMAIL_LOGO_URL=https://yourdomain.com/logo.png
 
-# ===================================
-# OPTIONAL CONFIGURATION
-# ===================================
+# ----------------------------------------
+# OPTIONAL FEATURES
+# ----------------------------------------
 
-# KEEP COMMENTED ON LOCAL; RECOMMENDED ON PRODUCTION
-# Main website URL (optional - redirects root URL to your main site in production)
-# If not set, root URL shows the local testing page
+# Resend Contacts sync (https://resend.com/audiences)
+# RESEND_AUDIENCE_ID=aud_xxxxx
+# RESEND_WEBHOOK_SECRET=whsec_xxxxx
+
+# Redirect root URL to main site (leave unset for local testing page)
 # MAIN_WEBSITE_URL=https://yourdomain.com
 
-# Custom redirect URLs (probably won't need to touch this unless you're making advanced customizations)
-CONFIRM_SUCCESS_URL=/waitlist-confirmed
-CONFIRM_ERROR_URL=/waitlist-error
-UNSUBSCRIBE_SUCCESS_URL=/unsubscribe-success
-UNSUBSCRIBE_ERROR_URL=/unsubscribe-error
+# Bot protection (https://dash.cloudflare.com → Turnstile)
+# TURNSTILE_SECRET_KEY=xxxxx
 
-# Cloudflare Turnstile (optional - for bot protection)
-# TURNSTILE_SECRET_KEY=your-turnstile-secret-key
+# Rate limiting (https://upstash.com)
+# UPSTASH_REDIS_REST_URL=https://xxx.upstash.io
+# UPSTASH_REDIS_REST_TOKEN=xxxxx
 
-# Upstash Redis (optional - for rate limiting)
-# UPSTASH_REDIS_REST_URL=https://your-redis.upstash.io
-# UPSTASH_REDIS_REST_TOKEN=your-redis-token
+# Disable double opt-in (not recommended)
+# DOUBLE_OPTIN=false
 
-# Double opt-in (optional - set to 'false' to disable; we recommend keeping it set to `true`)
-DOUBLE_OPTIN=true
+# ----------------------------------------
+# REDIRECT URLS (rarely need to change)
+# ----------------------------------------
 
-# ===================================
-# TEMPLATE CUSTOMIZATION EXAMPLES
-# ===================================
-
-# Example 1: Tech Startup (Minimal/Default)
-# EMAIL_TEMPLATE_STYLE=minimal
-# FROM_EMAIL=Acme Inc <hello@acme.com>
-
-# Example 2: Minimal Design Agency
-# EMAIL_TEMPLATE_STYLE=minimal  
-# FROM_EMAIL=Design Co <hi@designco.com>
-
-# Example 3: Professional Services
-# EMAIL_TEMPLATE_STYLE=professional
-# FROM_EMAIL=Law Firm <contact@lawfirm.com>
-
-# Example 4: Strong Brand Identity
-# EMAIL_TEMPLATE_STYLE=branded
-# FROM_EMAIL=Brand Co <team@brandco.com>
-
-# ===================================
-# DEVELOPMENT NOTES
-# ===================================
-
-# 1. Get Supabase credentials: https://supabase.com/dashboard
-# 2. Get Resend API key: https://resend.com/api-keys
-# 3. Set up your domain DNS records for email delivery
-# 4. Test email templates: npm run generate-email-previews
-# 5. Customize colors/content: edit the-widget/templates/config.js
-
-# For detailed setup instructions, see docs/QUICKSTART.md
+# CONFIRM_SUCCESS_URL=/waitlist-confirmed
+# CONFIRM_ERROR_URL=/waitlist-error
+# UNSUBSCRIBE_SUCCESS_URL=/unsubscribe-success
+# UNSUBSCRIBE_ERROR_URL=/unsubscribe-error

--- a/the-widget/supabase/README.md
+++ b/the-widget/supabase/README.md
@@ -13,6 +13,8 @@ This directory contains the SQL setup script for the waitlist widget database.
 
 The schema includes fields like `email_bounced` and `email_unsubscribed` that can be updated via Resend webhooks or any other email service's webhook system.
 
+**Resend Contacts Sync:** The optional Resend Contacts sync feature uses existing database fields - no schema changes required. When enabled, the API automatically syncs subscription status between Supabase and Resend Audiences. See the main [README.md](../../README.md#2b-set-up-resend-contacts-sync-optional) for setup instructions.
+
 ## Setup File
 
 ### `setup.sql` - Complete Setup (Recommended)

--- a/the-widget/templates/TEMPLATE_README.md
+++ b/the-widget/templates/TEMPLATE_README.md
@@ -4,15 +4,22 @@ This directory contains all the email templates used by the waitlist widget. You
 
 ## 🚀 Quick Start
 
-### **1. Choose Your Template Style**
+### **1. Set Branding via Environment Variables**
 
-Set your preferred template in your `.env` file:
+Configure your email branding in `.env`:
 
 ```bash
-# Choose one of: minimal (default), professional, branded
-# Note: 'default' is an alias for 'minimal' (backward compatibility)
-EMAIL_TEMPLATE_STYLE=minimal
+# Template style
+EMAIL_TEMPLATE_STYLE=minimal          # or professional, branded
+
+# Branding (optional - has defaults)
+EMAIL_PROJECT_NAME=Your Project
+EMAIL_SENDER_NAME=The Team
+EMAIL_PRIMARY_COLOR=#4f46e5
+EMAIL_LOGO_URL=https://yourdomain.com/logo.png
 ```
+
+For detailed message customization, edit `config.js` in this directory.
 
 ### **2. Restart Your Application**
 
@@ -121,25 +128,27 @@ EMAIL_TEMPLATE_STYLE=branded
 
 ### **Method 2: Content & Color Customization**
 
-Edit `templates/config.js` to customize content and colors:
+**Option A: Environment Variables (recommended for key branding)**
+
+```bash
+EMAIL_PROJECT_NAME=Your Startup
+EMAIL_SENDER_NAME=The Founder
+EMAIL_PRIMARY_COLOR=#4f46e5
+EMAIL_LOGO_URL=https://yourdomain.com/logo.png
+```
+
+**Option B: Edit `templates/config.js` (for detailed customization)**
 
 ```javascript
 export const emailConfig = {
-  // Company Information
-  projectName: "Your Startup",
-  senderName: "The Founder",
-  
-  // Logo Configuration (Professional & Branded templates only)
-  // Recommended: 200px wide max, PNG, JPG, or SVG format
-  // Maximum enforced: 250px wide (auto-scaled if larger)
-  // Branded templates: Shows gradient placeholder SVG if empty (unless brandedHeaderTextOnly is true)
-  // Professional templates: Hides logo if empty
-  logoUrl: "https://yourdomain.com/logo.png", // or "" for placeholder (branded) or hide (professional)
+  // These can also be set via environment variables (see above)
+  projectName: process.env.EMAIL_PROJECT_NAME || "Your Startup",
+  senderName: process.env.EMAIL_SENDER_NAME || "The Founder",
+  primaryColor: process.env.EMAIL_PRIMARY_COLOR || "#4f46e5",
+  logoUrl: process.env.EMAIL_LOGO_URL || "",
   
   // Branded template text-only header option
-  // If true and logoUrl is empty: Shows text (projectName) with primaryColor background
-  // If false and logoUrl is empty: Shows placeholder SVG logo with transparent background
-  brandedHeaderTextOnly: false, // Set to true for text-only header with background color
+  brandedHeaderTextOnly: process.env.EMAIL_BRANDED_TEXT_ONLY === 'true',
   
   // Brand Colors (affects all templates)
   primaryColor: "#6366f1",      // Your brand color
@@ -257,7 +266,12 @@ For advanced users who want to create completely custom templates:
 
 ### Change Brand Colors
 
-Edit `config.js`:
+Set via environment variable (recommended):
+```bash
+EMAIL_PRIMARY_COLOR=#your-brand-color
+```
+
+Or edit `config.js`:
 ```javascript
 primaryColor: "#your-brand-color",
 ```
@@ -266,7 +280,11 @@ primaryColor: "#your-brand-color",
 
 **Easy logo support for Professional and Branded templates:**
 
-1. **Set your logo URL** in `config.js`:
+1. **Set your logo URL** via environment variable (recommended):
+   ```bash
+   EMAIL_LOGO_URL=https://yourdomain.com/logo.png
+   ```
+   Or in `config.js`:
    ```javascript
    logoUrl: "https://yourdomain.com/logo.png", // Recommended: 200px max width
    ```

--- a/the-widget/templates/config.js
+++ b/the-widget/templates/config.js
@@ -1,28 +1,25 @@
 // Email Template Configuration
-// Edit these values to customize your email templates
+// Key branding values can be set via environment variables (recommended)
+// or edited directly here as fallbacks
 
 export const emailConfig = {
-  // Project/Company Information
-  projectName: "Your Project",
-  senderName: "The Team",
+  // Project/Company Information (set via EMAIL_PROJECT_NAME, EMAIL_SENDER_NAME)
+  projectName: process.env.EMAIL_PROJECT_NAME || "Your Project",
+  senderName: process.env.EMAIL_SENDER_NAME || "The Team",
   
-  // Logo Configuration
+  // Logo Configuration (set via EMAIL_LOGO_URL)
   // Recommended: 200px wide max, PNG, JPG, or SVG format
-  // Maximum enforced size: 250px wide (will be scaled down if larger)
-  // Branded templates: Shows placeholder SVG logo if logoUrl is empty (unless brandedHeaderTextOnly is true)
-  // Professional templates: Hides logo if logoUrl is empty
-  logoUrl: "", // e.g., "https://yourdomain.com/logo.png"
+  // Branded templates: Shows placeholder SVG if empty (unless brandedHeaderTextOnly is true)
+  logoUrl: process.env.EMAIL_LOGO_URL || "",
   
   // Branded template text-only header option
-  // If true and logoUrl is empty: Shows text (projectName) with primaryColor background
-  // If false and logoUrl is empty: Shows placeholder SVG logo with transparent background
-  brandedHeaderTextOnly: false, // Set to true for text-only header with background color
+  brandedHeaderTextOnly: process.env.EMAIL_BRANDED_TEXT_ONLY === 'true',
   
-  // Branding Colors
-  primaryColor: "#4f46e5",      // Button and link color
-  textColor: "#333",             // Main text color
-  headingColor: "#111",         // Heading text color
-  secondaryTextColor: "#666",   // Secondary text color
+  // Branding Colors (set via EMAIL_PRIMARY_COLOR)
+  primaryColor: process.env.EMAIL_PRIMARY_COLOR || "#4f46e5",
+  textColor: "#333",
+  headingColor: "#111",
+  secondaryTextColor: "#666",
   
   // Email Content
   confirmationSubject: "Confirm your waitlist signup",


### PR DESCRIPTION
Adds documentation and setup instructions for optional Resend Contacts sync, including two-way sync details and bulk migration script. Updates CORS configuration to use the CORS_ALLOWED_ORIGINS environment variable instead of hardcoded domains, and revises all related documentation, examples, and environment variable usage. Improves email template branding setup via environment variables and clarifies customization options throughout docs and config files.