### PR TITLE
Remove memory setting from Vercel functions config

### DIFF
--- a/the-widget/vercel.json
+++ b/the-widget/vercel.json
@@ -2,11 +2,9 @@
   "version": 2,
   "functions": {
     "api/*.js": {
-      "memory": 256,
       "maxDuration": 10
     },
     "api/webhooks/*.js": {
-      "memory": 256,
       "maxDuration": 10
     }
   },


### PR DESCRIPTION
Deleted the explicit 'memory' property from API and webhook function configurations in vercel.json, relying on default memory allocation.