### PR TITLE
update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Simple, tinkerer-friendly, mostly-drop-in waitlist widget built to work on stati
 
 ## TL;DR: Files to Copy to Your Jekyll Site
 
-Copy these 6 files from this repository to your Jekyll site:
+Copy these 8 files from this repository to your Jekyll site:
 
 | Source File | Destination in Jekyll Site |
 |------------|---------------------------|
@@ -22,6 +22,8 @@ Copy these 6 files from this repository to your Jekyll site:
 | `the-widget/assets/waitlist-pages.css` | `assets/waitlist-pages.css` |
 | `the-widget/jekyll/waitlist-confirmed.html` | Root folder (same level as `_config.yml`) |
 | `the-widget/jekyll/waitlist-error.html` | Root folder (same level as `_config.yml`) |
+| `the-widget/jekyll/unsubscribe-success.html` | Root folder (same level as `_config.yml`) |
+| `the-widget/jekyll/unsubscribe-error.html` | Root folder (same level as `_config.yml`) |
 
 **Quick copy commands** (replace `PATH_TO_REPO` with your repository path):
 ```bash
@@ -31,6 +33,8 @@ cp PATH_TO_REPO/the-widget/assets/waitlist-form.js assets/
 cp PATH_TO_REPO/the-widget/assets/waitlist-pages.css assets/
 cp PATH_TO_REPO/the-widget/jekyll/waitlist-confirmed.html .
 cp PATH_TO_REPO/the-widget/jekyll/waitlist-error.html .
+cp PATH_TO_REPO/the-widget/jekyll/unsubscribe-success.html .
+cp PATH_TO_REPO/the-widget/jekyll/unsubscribe-error.html .
 ```
 
 **Then:**
@@ -300,13 +304,15 @@ The `jekyll/` folder contains ready-to-use components. Adapt as needed for your 
 
 **Quick summary:**
 
-1. **Copy 6 files to your Jekyll site:**
+1. **Copy 8 files to your Jekyll site:**
    - `jekyll/_includes/waitlist-form.html` → `_includes/` (the form component)
    - `assets/waitlist-form.css` → `assets/` (form styling)
    - `assets/waitlist-form.js` → `assets/` (form functionality)
    - `assets/waitlist-pages.css` → `assets/` (confirmation page styling)
    - `jekyll/waitlist-confirmed.html` → your site root (success page)
    - `jekyll/waitlist-error.html` → your site root (error page)
+   - `jekyll/unsubscribe-success.html` → your site root (unsubscribe success page)
+   - `jekyll/unsubscribe-error.html` → your site root (unsubscribe error page)
 
 2. **Add the form to any page:**
    ```liquid

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -246,7 +246,7 @@ npm install
 
 **What you're doing:** You're copying files from this repository into your Jekyll site so the waitlist form can work. Think of it like adding a new feature to your website.
 
-**Files you need to copy:** 6 files total
+**Files you need to copy:** 8 files total
 
 ---
 
@@ -319,6 +319,12 @@ cp PATH_TO_REPO/the-widget/jekyll/waitlist-confirmed.html .
 
 # 6. Copy the error page (shown if confirmation fails)
 cp PATH_TO_REPO/the-widget/jekyll/waitlist-error.html .
+
+# 7. Copy the unsubscribe success page (shown after successful unsubscribe)
+cp PATH_TO_REPO/the-widget/jekyll/unsubscribe-success.html .
+
+# 8. Copy the unsubscribe error page (shown if unsubscribe fails)
+cp PATH_TO_REPO/the-widget/jekyll/unsubscribe-error.html .
 ```
 
 **Real example:** If your repo is at `~/projects/emberwisp-waitlist`, the commands would be:
@@ -329,13 +335,15 @@ cp ~/projects/emberwisp-waitlist/the-widget/assets/waitlist-form.js assets/
 cp ~/projects/emberwisp-waitlist/the-widget/assets/waitlist-pages.css assets/
 cp ~/projects/emberwisp-waitlist/the-widget/jekyll/waitlist-confirmed.html .
 cp ~/projects/emberwisp-waitlist/the-widget/jekyll/waitlist-error.html .
+cp ~/projects/emberwisp-waitlist/the-widget/jekyll/unsubscribe-success.html .
+cp ~/projects/emberwisp-waitlist/the-widget/jekyll/unsubscribe-error.html .
 ```
 
 **Alternative: Manual Copying**
 If you prefer using your file manager (Finder on Mac, File Explorer on Windows):
 1. Open the repository folder: `the-widget/jekyll/_includes/waitlist-form.html`
 2. Copy it to your Jekyll site's `_includes/` folder
-3. Repeat for all 6 files, putting them in the correct locations as shown above
+3. Repeat for all 8 files, putting them in the correct locations as shown above
 
 **How to verify:** After copying, check that these files exist in your Jekyll site:
 - `_includes/waitlist-form.html` ✅
@@ -344,6 +352,8 @@ If you prefer using your file manager (Finder on Mac, File Explorer on Windows):
 - `assets/waitlist-pages.css` ✅
 - `waitlist-confirmed.html` (in your site's root folder) ✅
 - `waitlist-error.html` (in your site's root folder) ✅
+- `unsubscribe-success.html` (in your site's root folder) ✅
+- `unsubscribe-error.html` (in your site's root folder) ✅
 
 **Important note about confirmation and unsubscribe pages:**
 - These pages must be on **your Jekyll site**, not on the API
@@ -441,6 +451,8 @@ title: Home
 - `assets/waitlist-pages.css` exists
 - `waitlist-confirmed.html` exists in root
 - `waitlist-error.html` exists in root
+- `unsubscribe-success.html` exists in root
+- `unsubscribe-error.html` exists in root
 
 ✅ **Form added to a page:**
 - You added the `{% include waitlist-form.html ... %}` line to at least one page
@@ -609,7 +621,7 @@ Replace `0x4AAAAAAA...` with your actual site key from Cloudflare.
 - Check Resend dashboard → Logs for delivery status
 
 ### Confirmation link doesn't work
-- Make sure `waitlist-confirmed.html` and `waitlist-error.html` are in your site's root folder
+- Make sure `waitlist-confirmed.html`, `waitlist-error.html`, `unsubscribe-success.html`, and `unsubscribe-error.html` are in your site's root folder
 - Check that `BASE_URL` in Vercel matches your site's domain (and is set to Production environment)
 - Verify the confirmation pages are deployed with your site
 

--- a/the-widget/jekyll/_includes/waitlist-form.html
+++ b/the-widget/jekyll/_includes/waitlist-form.html
@@ -7,6 +7,7 @@
   - Double opt-in support
   
   Usage in your Jekyll page/layout:
+{% raw %}
     {% include waitlist-form.html %}
   
   With source tracking:
@@ -17,6 +18,7 @@
   
   With custom API URL:
     {% include waitlist-form.html api_url="https://your-api.vercel.app/api/subscribe" %}
+{% endraw %}
 -->
 
 <!-- Load widget styles -->


### PR DESCRIPTION
This pull request updates documentation and example code to reflect the addition of two new unsubscribe-related pages to the waitlist widget integration for Jekyll sites. The instructions now consistently reference 8 files to copy, including the new unsubscribe success and error pages, and clarify their required locations. Example code snippets and verification steps are also updated for accuracy.

**Documentation updates for required files:**

* README and `docs/QUICKSTART.md` now specify copying 8 files (including `unsubscribe-success.html` and `unsubscribe-error.html`) instead of 6, with updated tables, lists, and example commands. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R13-R48) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L271-R315) [[3]](diffhunk://#diff-86a7695eb7559a8d3b6914182edf3330d1ebb137bff7455cd342daf24d44ebb6L249-R249) [[4]](diffhunk://#diff-86a7695eb7559a8d3b6914182edf3330d1ebb137bff7455cd342daf24d44ebb6R322-R327) [[5]](diffhunk://#diff-86a7695eb7559a8d3b6914182edf3330d1ebb137bff7455cd342daf24d44ebb6R338-R346)
* Verification steps and troubleshooting instructions now include checks for the presence of the unsubscribe pages in the site root. [[1]](diffhunk://#diff-86a7695eb7559a8d3b6914182edf3330d1ebb137bff7455cd342daf24d44ebb6R355-R356) [[2]](diffhunk://#diff-86a7695eb7559a8d3b6914182edf3330d1ebb137bff7455cd342daf24d44ebb6R454-R455) [[3]](diffhunk://#diff-86a7695eb7559a8d3b6914182edf3330d1ebb137bff7455cd342daf24d44ebb6L612-R624)

**Code example improvements:**

* Added `{% raw %}` and `{% endraw %}` tags around Liquid template usage in `waitlist-form.html` to prevent Jekyll from rendering example code in documentation. [[1]](diffhunk://#diff-b28d87c93e57280d502f3afe3d288b681c5f150cfbcc2d30df2b793db574060dR10) [[2]](diffhunk://#diff-b28d87c93e57280d502f3afe3d288b681c5f150cfbcc2d30df2b793db574060dR21)